### PR TITLE
Update main.scss to add vertical Scroll Bar

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -60,6 +60,7 @@ body, html {
 
   padding: 15px;
   padding: 8px;
+  overflow-y: scroll;
 
   .CodeMirror-code .cm-comment {
     background: var(--sn-stylekit-contrast-background-color);


### PR DESCRIPTION
There's currently no vertical scroll bar. Adding this line with the Inspector adds the vertical scroll bar on my Windows 10 Desktop, Firefox, and Google Chrome web apps. I have not tested it on mobile, and I have not tried compiling the editor with this addition. 