### PR TITLE
fix: mark selected text

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <script src="vendor/codemirror/addon/mode/loadmode.js"></script>
     <script src="vendor/codemirror/mode/meta.js"></script>
     <script src="dist/lib/component-relay.js"></script>
+    <!-- Required for styling selected text -->
+    <script src="vendor/codemirror/addon/selection/mark-selection.js"></script>
     <script>
       CodeMirror.modeURL = "vendor/codemirror/mode/%N/%N.js";
     </script>


### PR DESCRIPTION
## Summary
In `v1.3.6`, selected text is not styled despite setting `styleSelectedText: true,` in `main.js`: https://github.com/standardnotes/code-editor/blob/6e50ed49c53147bb82bd7f3288e3cf55ce0e515d/src/main.js#L104

This PR fixes this by importing `vendor/codemirror/addon/selection/mark-selection.js` in `index.html`. 

## Screenshots

### `v1.3.5` / Previous Behavior
![image](https://user-images.githubusercontent.com/22967798/106819851-38f4de80-662f-11eb-8a69-39aaf277ddeb.png)

### `v1.3.6` / Current Behavior
![image](https://user-images.githubusercontent.com/22967798/106820188-c2a4ac00-662f-11eb-8189-01cb2f2b690a.png)


### After this PR
![image](https://user-images.githubusercontent.com/22967798/106820076-9d17a280-662f-11eb-8ac8-6ce7b22a5cf7.png)
